### PR TITLE
[CUBRIDQA-1191] The cub_master is not executed on the CUBRID docker container (develop)

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:7
 
 RUN groupadd -r cubrid && useradd -r -g cubrid -d /home/cubrid -m cubrid
+RUN chmod 777 -R /tmp
 
 ENV GOSU_VERSION 1.13
 RUN set -x \


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1191, #11