### PR TITLE
[CUBRIDQA-1329] Changed Base OS (CentOS 7 -> Rocky Linux 8)

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -1,6 +1,6 @@
 FROM rockylinux:8
 
-ENV GOSU_VERSION 1.13
+ENV GOSU_VERSION 1.19
 RUN set -x \
 	&& dnf -y install epel-release ncurses-compat-libs \
 	&& dnf -y install wget dpkg \

--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -1,14 +1,9 @@
-FROM centos:7
-
-RUN groupadd -r cubrid && useradd -r -g cubrid -d /home/cubrid -m cubrid
-RUN chmod 777 -R /tmp
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+FROM rockylinux:8
 
 ENV GOSU_VERSION 1.13
 RUN set -x \
-	&& yum -y install epel-release \
-	&& yum -y install wget dpkg \
+	&& dnf -y install epel-release ncurses-compat-libs \
+	&& dnf -y install wget dpkg \
 	&& dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
 	&& wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
 	&& wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
@@ -18,7 +13,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /tmp/gosu.asc \
 	&& chmod +x /usr/bin/gosu \
 	&& gosu nobody true \
-	&& yum -y remove dpkg 
+	&& dnf -y remove dpkg 
 
 ENV CUBRID_VERSION 10.2-latest
 ENV CUBRID /home/cubrid/CUBRID
@@ -30,13 +25,18 @@ ENV CUBRID_COMPONENTS ALL
 ENV PATH $CUBRID/bin:$PATH
 ENV LD_LIBRARY_PATH=$CUBRID/lib
 
+# Create user and group
+RUN groupadd -r -g 1000 cubrid && \
+    useradd -r -u 1000 -g cubrid -d /home/cubrid -m cubrid && \
+    chmod 777 -R /tmp
+
 RUN set -x \
 	&& wget -O cubrid.tar.gz http://ftp.cubrid.org/CUBRID_Engine/10.2_latest/CUBRID-$CUBRID_VERSION-Linux.x86_64.tar.gz \
 	&& tar -xzf cubrid.tar.gz -C /home/cubrid && rm cubrid.tar.gz \
 	&& mkdir -p $CUBRID_DATABASES \
 	&& chown -R cubrid:cubrid $CUBRID $CUBRID_DATABASES \
-	&& yum -y remove wget \
-	&& yum clean all
+	&& dnf -y remove wget \
+	&& dnf clean all
 
 VOLUME $CUBRID_DATABASES
 

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM rockylinux:8
 
-ENV GOSU_VERSION 1.13
+ENV GOSU_VERSION 1.19
 RUN set -x \
 	&& dnf -y install epel-release ncurses-compat-libs \
 	&& dnf -y install wget dpkg \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -1,14 +1,9 @@
-FROM centos:7
-
-RUN groupadd -r cubrid && useradd -r -g cubrid -d /home/cubrid -m cubrid
-RUN chmod 777 -R /tmp
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+FROM rockylinux:8
 
 ENV GOSU_VERSION 1.13
 RUN set -x \
-	&& yum -y install epel-release \
-	&& yum -y install wget dpkg \
+	&& dnf -y install epel-release ncurses-compat-libs \
+	&& dnf -y install wget dpkg \
 	&& dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
 	&& wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
 	&& wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
@@ -18,7 +13,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /tmp/gosu.asc \
 	&& chmod +x /usr/bin/gosu \
 	&& gosu nobody true \
-	&& yum -y remove dpkg 
+	&& dnf -y remove dpkg 
 
 ENV CUBRID_VERSION 11.0-latest
 ENV CUBRID /home/cubrid/CUBRID
@@ -30,13 +25,18 @@ ENV CUBRID_COMPONENTS ALL
 ENV PATH $CUBRID/bin:$PATH
 ENV LD_LIBRARY_PATH=$CUBRID/lib
 
+# Create user and group
+RUN groupadd -r -g 1000 cubrid && \
+    useradd -r -u 1000 -g cubrid -d /home/cubrid -m cubrid && \
+    chmod 777 -R /tmp
+
 RUN set -x \
 	&& wget -O cubrid.tar.gz http://ftp.cubrid.org/CUBRID_Engine/11.0_latest/CUBRID-$CUBRID_VERSION-Linux.x86_64.tar.gz \
 	&& tar -xzf cubrid.tar.gz -C /home/cubrid && rm cubrid.tar.gz \
 	&& mkdir -p $CUBRID_DATABASES \
 	&& chown -R cubrid:cubrid $CUBRID $CUBRID_DATABASES \
-	&& yum -y remove wget \
-	&& yum clean all
+	&& dnf -y remove wget \
+	&& dnf clean all
 
 VOLUME $CUBRID_DATABASES
 

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -1,6 +1,6 @@
 FROM rockylinux:8
 
-ENV GOSU_VERSION 1.13
+ENV GOSU_VERSION 1.19
 RUN set -x \
 	&& dnf -y install epel-release ncurses-compat-libs \
 	&& dnf -y install wget dpkg \

--- a/11.2/Dockerfile
+++ b/11.2/Dockerfile
@@ -1,14 +1,9 @@
-FROM centos:7
-
-RUN groupadd -r cubrid && useradd -r -g cubrid -d /home/cubrid -m cubrid
-RUN chmod 777 -R /tmp
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+FROM rockylinux:8
 
 ENV GOSU_VERSION 1.13
 RUN set -x \
-	&& yum -y install epel-release \
-	&& yum -y install wget dpkg \
+	&& dnf -y install epel-release ncurses-compat-libs \
+	&& dnf -y install wget dpkg \
 	&& dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
 	&& wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
 	&& wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
@@ -18,7 +13,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /tmp/gosu.asc \
 	&& chmod +x /usr/bin/gosu \
 	&& gosu nobody true \
-	&& yum -y remove dpkg 
+	&& dnf -y remove dpkg 
 
 ENV CUBRID_VERSION 11.2-latest
 ENV CUBRID /home/cubrid/CUBRID
@@ -30,13 +25,18 @@ ENV CUBRID_COMPONENTS ALL
 ENV PATH $CUBRID/bin:$PATH
 ENV LD_LIBRARY_PATH=$CUBRID/lib
 
+# Create user and group
+RUN groupadd -r -g 1000 cubrid && \
+    useradd -r -u 1000 -g cubrid -d /home/cubrid -m cubrid && \
+    chmod 777 -R /tmp
+
 RUN set -x \
 	&& wget -O cubrid.tar.gz http://ftp.cubrid.org/CUBRID_Engine/11.2_latest/CUBRID-$CUBRID_VERSION-Linux.x86_64.tar.gz \
 	&& tar -xzf cubrid.tar.gz -C /home/cubrid && rm cubrid.tar.gz \
 	&& mkdir -p $CUBRID_DATABASES \
 	&& chown -R cubrid:cubrid $CUBRID $CUBRID_DATABASES \
-	&& yum -y remove wget \
-	&& yum clean all
+	&& dnf -y remove wget \
+	&& dnf clean all
 
 VOLUME $CUBRID_DATABASES
 

--- a/11.3/Dockerfile
+++ b/11.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM rockylinux:8
 
-ENV GOSU_VERSION 1.13
+ENV GOSU_VERSION 1.19
 RUN set -x \
 	&& dnf -y install epel-release \
 	&& dnf -y install wget dpkg \

--- a/11.3/Dockerfile
+++ b/11.3/Dockerfile
@@ -1,14 +1,9 @@
-FROM centos:7
-
-RUN groupadd -r cubrid && useradd -r -g cubrid -d /home/cubrid -m cubrid
-RUN chmod 777 -R /tmp
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+FROM rockylinux:8
 
 ENV GOSU_VERSION 1.13
 RUN set -x \
-	&& yum -y install epel-release \
-	&& yum -y install wget dpkg \
+	&& dnf -y install epel-release \
+	&& dnf -y install wget dpkg \
 	&& dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
 	&& wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
 	&& wget -O /tmp/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
@@ -18,7 +13,7 @@ RUN set -x \
 	&& rm -r "$GNUPGHOME" /tmp/gosu.asc \
 	&& chmod +x /usr/bin/gosu \
 	&& gosu nobody true \
-	&& yum -y remove dpkg 
+	&& dnf -y remove dpkg 
 
 ENV CUBRID_VERSION 11.3-latest
 ENV CUBRID /home/cubrid/CUBRID
@@ -30,13 +25,18 @@ ENV CUBRID_COMPONENTS ALL
 ENV PATH $CUBRID/bin:$PATH
 ENV LD_LIBRARY_PATH=$CUBRID/lib
 
+# Create user and group
+RUN groupadd -r -g 1000 cubrid && \
+    useradd -r -u 1000 -g cubrid -d /home/cubrid -m cubrid && \
+    chmod 777 -R /tmp
+
 RUN set -x \
 	&& wget -O cubrid.tar.gz http://ftp.cubrid.org/CUBRID_Engine/11.3_latest/CUBRID-$CUBRID_VERSION-Linux.x86_64.tar.gz \
 	&& tar -xzf cubrid.tar.gz -C /home/cubrid && rm cubrid.tar.gz \
 	&& mkdir -p $CUBRID_DATABASES \
 	&& chown -R cubrid:cubrid $CUBRID $CUBRID_DATABASES \
-	&& yum -y remove wget \
-	&& yum clean all
+	&& dnf -y remove wget \
+	&& dnf clean all
 
 VOLUME $CUBRID_DATABASES
 

--- a/11.4/Dockerfile
+++ b/11.4/Dockerfile
@@ -3,7 +3,7 @@ FROM rockylinux:8
 
 
 # Set environment variables
-ENV GOSU_VERSION="1.13" \
+ENV GOSU_VERSION="1.19" \
     CUBRID_VERSION="11.4-latest" \
     VERSION_PATH="11.4_latest" \
     CUBRID_USER_PATH="/home/cubrid" \

--- a/11.4/Dockerfile
+++ b/11.4/Dockerfile
@@ -1,9 +1,6 @@
-FROM centos:7
+FROM rockylinux:8
 
-# Create user and group
-RUN groupadd -r -g 1000 cubrid && \
-    useradd -r -u 1000 -g cubrid -d /home/cubrid -m cubrid && \
-    chmod 777 -R /tmp
+
 
 # Set environment variables
 ENV GOSU_VERSION="1.13" \
@@ -22,14 +19,17 @@ ENV GOSU_VERSION="1.13" \
     
 
 # Setup repositories and install base packages
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
-    yum -y update && \
-    yum -y install epel-release && \
-    yum -y install wget unzip zip htop lsof tzdata \
+RUN dnf -y update && \
+    dnf -y install epel-release && \
+    dnf -y install wget unzip zip htop lsof tzdata tar gzip \
     net-tools iproute telnet bind-utils nmap traceroute socat tcpdump \
-    httpie rsync openssh-clients openssh less nc && \ 
-    yum clean all
+    httpie rsync openssh-clients openssh less nc shadow-utils
+RUN dnf clean all
+
+# Create user and group
+RUN groupadd -r -g 1000 cubrid && \
+    useradd -r -u 1000 -g cubrid -d /home/cubrid -m cubrid && \
+    chmod 777 -R /tmp
 
 # Install gosu
 RUN wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
@@ -83,9 +83,11 @@ RUN wget -O cubrid.tar.gz "http://ftp.cubrid.org/CUBRID_Engine/${VERSION_PATH}/C
     rm cubrid.tar.gz && \
     mkdir -p ${CUBRID_DATABASES} ${CUBRID_BACKUPDB} && \
     chown -R cubrid:cubrid ${CUBRID} ${CUBRID_DATABASES} ${CUBRID_BACKUPDB} && \
-    chmod -R 755 /home/cubrid/CUBRID && \
-    yum clean all && \
-    rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
+    chmod -R 755 /home/cubrid/CUBRID
+RUN dnf clean all
+
+# Clean up cache
+RUN rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 
 # Copy scripts and set permissions
 COPY operator_conf.sh backupdb.sh ${CUBRID}/share/scripts/


### PR DESCRIPTION
Refer to http://jira.cubrid.org/browse/CUBRIDQA-1329

Cent OS 7이 EOL됨에 따라 CUBRID docker image의 Base OS를 Rocky Linux 8으로 변경합니다.
Base OS가 Rocky 8으로 변경되는건 26년 패치 릴리스부터입니다.
(기존 배포된 이미지의 Base OS를 변경하지는 않음)

적용 버전: 10.2, 11.0, 11.2, 11.3, 11.4
End of Service 로 인한 미적용 버전: 10.0, 10.1

그 외에 추가 수정 사항

1. 11.2 이하 버전 image에 'ncurses-compat-libs' 패키지를 추가 설치
   - 11.3 이상은 ncurses 종속성이 제거되어 불필요 (관련 이슈: http://jira.cubrid.org/browse/CBRD-24669 )
2. 11.3 이하 버전 image의 cubrid 계정에 root 권한 추가 
   - 기존에는 cubrid 계정에 root 권한이 없어, root 계정으로만 engine을 handling 할 수 있었음 (지원팀 요청사항)
3. gosu 패키지의 보안 취약점을 보완하기 위하여 1.13 -> 1.19 변경
   - 참고: http://jira.cubrid.org/browse/CUBRIDQA-1332