### PR TITLE
[CBRD-26778] Run csql with gosu cubrid to prevent root owned PL files

### DIFF
--- a/10.2/docker-entrypoint.sh
+++ b/10.2/docker-entrypoint.sh
@@ -29,7 +29,7 @@ init_db () {
 		&& gosu cubrid cubrid createdb --db-volume-size=$CUBRID_VOLUME_SIZE --server-name=$CUBRID_SERVER_NAME $CUBRID_DB $CUBRID_LOCALE
 
 	if [ "$CUBRID_USER" -a "$CUBRID_USER" != "dba" -a "$CUBRID_USER" != "public" ]; then
-		csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
+		gosu cubrid csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
 	fi
 }
 

--- a/11.0/docker-entrypoint.sh
+++ b/11.0/docker-entrypoint.sh
@@ -29,7 +29,7 @@ init_db () {
 		&& gosu cubrid cubrid createdb --db-volume-size=$CUBRID_VOLUME_SIZE --server-name=$CUBRID_SERVER_NAME $CUBRID_DB $CUBRID_LOCALE
 
 	if [ "$CUBRID_USER" -a "$CUBRID_USER" != "dba" -a "$CUBRID_USER" != "public" ]; then
-		csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
+		gosu cubrid csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
 	fi
 }
 

--- a/11.2/docker-entrypoint.sh
+++ b/11.2/docker-entrypoint.sh
@@ -29,7 +29,7 @@ init_db () {
 		&& gosu cubrid cubrid createdb --db-volume-size=$CUBRID_VOLUME_SIZE --server-name=$CUBRID_SERVER_NAME $CUBRID_DB $CUBRID_LOCALE
 
 	if [ "$CUBRID_USER" -a "$CUBRID_USER" != "dba" -a "$CUBRID_USER" != "public" ]; then
-		csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
+		gosu cubrid csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
 	fi
 }
 

--- a/11.3/docker-entrypoint.sh
+++ b/11.3/docker-entrypoint.sh
@@ -29,7 +29,7 @@ init_db () {
 		&& gosu cubrid cubrid createdb --db-volume-size=$CUBRID_VOLUME_SIZE --server-name=$CUBRID_SERVER_NAME $CUBRID_DB $CUBRID_LOCALE
 
 	if [ "$CUBRID_USER" -a "$CUBRID_USER" != "dba" -a "$CUBRID_USER" != "public" ]; then
-		csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
+		gosu cubrid csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
 	fi
 }
 

--- a/11.4/docker-entrypoint.sh
+++ b/11.4/docker-entrypoint.sh
@@ -98,7 +98,7 @@ init_db () {
 		&& gosu cubrid cubrid createdb --db-volume-size=$CUBRID_VOLUME_SIZE --server-name=$CUBRID_SERVER_NAME $CUBRID_DB $CUBRID_LOCALE
 
 	if [ "$CUBRID_USER" -a "$CUBRID_USER" != "dba" -a "$CUBRID_USER" != "public" ]; then
-		csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
+		gosu cubrid csql -u dba -S $CUBRID_DB -c "CREATE USER $CUBRID_USER PASSWORD '$CUBRID_PASSWORD';"
 	fi
 }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-26778

### Purpose
`CUBRID_USER` 환경변수를 지정해 컨테이너 실행 시 PL 서버 실행에 실패해 컨테이너가 종료되는 문제를 해결합니다.

### Implementation
`csql` 호출 에 `gosu cubrid`를 불여 cubrid OS 사용자로 실행될 수 있도록 수정합니다.

### Remarks
서비스 실행이 안되는 문제는 11.4 버전에서만 발생하지만, 아직 EOL이 남은 버전들에도 `gosu cubrid`가 누락되어 있어 같이 수정했습니다.